### PR TITLE
MOD: use WaitGroup to ensure shutting down gracefully

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -494,6 +494,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 
 // Wait for the stop, and do cleanups
 func (s *Server) waitForShutdown(stop <-chan struct{}) {
+	s.requiredTerminations.Add(1)
 	go func() {
 		<-stop
 		s.fileWatcher.Close()
@@ -537,6 +538,8 @@ func (s *Server) waitForShutdown(stop <-chan struct{}) {
 		if s.IstioDNSServer != nil {
 			s.IstioDNSServer.Close()
 		}
+		
+		s.requiredTerminations.Done()
 	}()
 }
 


### PR DESCRIPTION
This PR can ensure waitForShutdown called before the whole process exits

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[* ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[*] Developer Infrastructure
